### PR TITLE
Added check for null in CommandMessage.getLength

### DIFF
--- a/src/main/java/sockslib/server/msg/CommandMessage.java
+++ b/src/main/java/sockslib/server/msg/CommandMessage.java
@@ -140,10 +140,12 @@ public class CommandMessage implements ReadableMessage, WritableMessage {
         break;
     }
 
-    bytes[0] = (byte) version;
-    bytes[1] = (byte) command.getValue();
-    bytes[2] = RESERVED;
-    bytes[3] = (byte) addressType;
+    if (bytes != null) {
+      bytes[0] = (byte) version;
+      bytes[1] = (byte) command.getValue();
+      bytes[2] = RESERVED;
+      bytes[3] = (byte) addressType;
+    }
 
     return bytes;
   }

--- a/src/main/java/sockslib/server/msg/CommandMessage.java
+++ b/src/main/java/sockslib/server/msg/CommandMessage.java
@@ -101,7 +101,8 @@ public class CommandMessage implements ReadableMessage, WritableMessage {
 
   @Override
   public int getLength() {
-    return getBytes().length;
+    byte[] bytes = getBytes();
+    return (bytes != null) ? bytes.length : 0;
   }
 
   @Override


### PR DESCRIPTION
I have run some tests and in cases where `getBytes()` returned `null`, the `addressType` has been `0`. Since `addressType` is set in `read()` it is likely that `socksException` has also been set (I didn't verify this).

So an alternative solution might be to check for the exception between these two lines:

    @Override
    public int read(ReadableMessage message) throws SocksException, IOException {
      message.read(inputStream);
      return message.getLength();
    }

On the other hand, it doesn't look like any caller of `read(..)` is using the return value? So we might as well return `void` instead and no longer do the `return message.getLength();` call.