### PR TITLE
Remove polling from the proxy server

### DIFF
--- a/src/main/java/sockslib/server/SocksHandler.java
+++ b/src/main/java/sockslib/server/SocksHandler.java
@@ -103,20 +103,6 @@ public interface SocksHandler extends Runnable {
    */
   void setBufferSize(int bufferSize);
 
-  /**
-   * Returns idle time.
-   *
-   * @return idle time.
-   */
-  int getIdleTime();
-
-  /**
-   * Sets idle time.
-   *
-   * @param idleTime Idle time.
-   */
-  void setIdleTime(int idleTime);
-
   void setProxy(SocksProxy socksProxy);
 
   SocksProxyServer getSocksProxyServer();

--- a/src/main/java/sockslib/server/io/SocketPipe.java
+++ b/src/main/java/sockslib/server/io/SocketPipe.java
@@ -110,11 +110,10 @@ public class SocketPipe implements Pipe {
   @Override
   public boolean stop() {
     if (running) {
+      // Ensure that isRunning() returns false when PipeListener.onStop() runs.
+      running = false;
       pipe1.stop();
       pipe2.stop();
-      if (!pipe1.isRunning() && !pipe2.isRunning()) {
-        running = false;
-      }
     }
     return running;
   }


### PR DESCRIPTION
By default, the server currently polls every two seconds
while waiting for an active connection to terminate, before
freeing relevant resources.  This is inefficient for idle
and short-lived connections.

In this change, the polling is removed.  Instead, the server
thread sleeps until it is woken up by an event indicating that
the connection has terminated or should be terminated.

This change also slightly alters the SocketPipe stop procedure,
to ensure that all PipeListeners see a consistent view of the
Pipe during onStop.